### PR TITLE
:sparkles:  fix linter issues with registry

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -265,7 +265,6 @@ run:
   - exp/runtime/hooks
   - exp/runtime/internal
   - internal/runtime/client
-  - internal/runtime/registry
   - internal/runtime/server
   - poc
   - runtime-openapi-gen

--- a/internal/runtime/registry/doc.go
+++ b/internal/runtime/registry/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry implements the registry for runtime extensions.
+package registry

--- a/internal/runtime/registry/registry.go
+++ b/internal/runtime/registry/registry.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
-// TODO: handle namespace selector
+// TODO: handle namespace selector.
 
 var (
 	once     sync.Once
@@ -192,7 +192,7 @@ func (extensions *extensionRegistry) Get(name string) (*RuntimeExtensionRegistra
 	extensions.lock.RLock()
 	defer extensions.lock.RUnlock()
 
-	r, _ := extensions.items[name]
+	r := extensions.items[name]
 	return r, nil
 }
 

--- a/internal/runtime/registry/registry_test.go
+++ b/internal/runtime/registry/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
@@ -31,12 +32,13 @@ func TestWarmUpExtensions(t *testing.T) {
 	g := NewWithT(t)
 
 	e := extensions()
-	e.WarmUp(&runtimev1.ExtensionList{})
-
+	err := e.WarmUp(&runtimev1.ExtensionList{})
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(e.IsReady()).To(BeTrue())
+
 	g.Expect(e.Add(&runtimev1.Extension{})).To(Succeed())
 	g.Expect(e.Remove(&runtimev1.Extension{})).To(Succeed())
-	_, err := e.List(catalog.GroupVersionHook{Group: "foo", Version: "bar", Hook: "bak"})
+	_, err = e.List(catalog.GroupVersionHook{Group: "foo", Version: "bar", Hook: "bak"})
 	g.Expect(err).ToNot(HaveOccurred())
 	_, err = e.Get("foo")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -106,7 +108,9 @@ func TestExtensions(t *testing.T) {
 	e := extensions()
 
 	// WarmUp with extension1
-	e.WarmUp(&runtimev1.ExtensionList{Items: []runtimev1.Extension{*extension1}})
+	err := e.WarmUp(&runtimev1.ExtensionList{Items: []runtimev1.Extension{*extension1}})
+	g.Expect(err).ToNot(HaveOccurred())
+
 	g.Expect(e.IsReady()).To(BeTrue())
 
 	// Get an extension by name


### PR DESCRIPTION
Removed the linter exception for the now merged registry package. 

Fixed some minor linting issues found in registry.
