### PR TITLE
pr-runtime-sdk tls for extension servers

### DIFF
--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/transport"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1beta1"
@@ -321,9 +322,10 @@ func httpCall(ctx context.Context, request, response runtime.Object, opts *httpC
 		if err != nil {
 			return errors.Wrap(err, "failed to create tls config")
 		}
-		client.Transport = &http.Transport{
+		// this also adds http2
+		client.Transport = utilnet.SetTransportDefaults(&http.Transport{
 			TLSClientConfig: tlsConfig,
-		}
+		})
 	}
 	resp, err := client.Do(httpRequest)
 	// TODO:  handle error in conjunction with FailurePolicy

--- a/poc/local/README.md
+++ b/poc/local/README.md
@@ -29,3 +29,23 @@ Deploy
 # Deploy Extension
 kubectl apply -f ./extension.yaml
 ```
+
+# Secure one
+
+```sh
+# to create service and certitficate
+kubectl apply -f secure-infra.yaml
+
+# fetch certificate
+mkdir -p /tmp/rte-implementation-secure
+for f in $(kubectl get secret my-local-extension-cert -o json | jq '.data | keys | .[]' -r); do 
+  kubectl get secret my-local-extension-cert -o json | jq '.data["'$f'"]' -r | base64 -d > "/tmp/rte-implementation-secure/$f"
+done
+
+# replace caBundle in `secure-extension.yaml` with base64 encoded content of /tmp/rte-implementation-secure/ca.crt
+
+# start webserver now (IDE?) rte-implementation-v1alpha1-secure
+
+# Deploy Extension
+kubectl apply -f secure-extension.yaml
+```

--- a/poc/local/secure-extension.yaml
+++ b/poc/local/secure-extension.yaml
@@ -1,0 +1,13 @@
+apiVersion: runtime.cluster.x-k8s.io/v1beta1
+kind: Extension
+metadata:
+  name: "my-local-extensions"
+spec:
+  clientConfig:
+    caBundle: REPLACEME
+    service:
+      name: my-local-extension
+      namespace: default
+      port: 8083
+    # url: "https://my-local-extension.default.svc.cluster.local:8083"
+  namespaceSelector: {}

--- a/poc/local/secure-infra.yaml
+++ b/poc/local/secure-infra.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-local-extension
+  namespace: default
+spec:
+  type: ExternalName
+  externalName: docker.for.mac.localhost
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-local-extension-serving-cert
+spec:
+  dnsNames:
+  - my-local-extension.default.svc
+  - my-local-extension.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: my-local-extension-selfsigned-issuer
+  secretName: my-local-extension-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: my-local-extension-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}

--- a/poc/test/rte-implementation-v1alpha1-secure/main.go
+++ b/poc/test/rte-implementation-v1alpha1-secure/main.go
@@ -1,19 +1,14 @@
 package main
 
 import (
-	"context"
-	"crypto/tls"
-	"errors"
 	"flag"
 	"fmt"
-	"net"
 	"net/http"
-	"path/filepath"
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1beta1"
 	"sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -24,58 +19,23 @@ import (
 // go run rte/test/rte-implementation-v1alpha2/main.go
 
 var c = catalog.New()
-var certDir = flag.String("certDir", "", "path to directory containing tls.crt and tls.key")
-var enableTLS = flag.Bool("enableTLS", false, "enables TLS webserver")
+var certDir = flag.String("certDir", "/tmp/rte-implementation-secure/", "path to directory containing tls.crt and tls.key")
 
 func init() {
 	_ = v1alpha1.AddToCatalog(c)
 }
 
 func main() {
-	flag.Parse()
-
 	ctx := ctrl.SetupSignalHandler()
 
-	var listener net.Listener
-	var err error
-
-	if *enableTLS {
-		if *certDir == "" {
-			panic(errors.New("expected certDir to find path to tls.crt and tls.key"))
-		}
-
-		// see https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/webhook/server.go#L210
-		certPath := filepath.Join(*certDir, "tls.crt")
-		keyPath := filepath.Join(*certDir, "tls.key")
-
-		certWatcher, err := certwatcher.New(certPath, keyPath)
-		if err != nil {
-			panic(err)
-		}
-
-		go func() {
-			if err := certWatcher.Start(ctx); err != nil {
-				fmt.Printf("error: certificate watcher error %v\n", err)
-			}
-		}()
-
-		cfg := &tls.Config{ //nolint:gosec
-			NextProtos:     []string{"h2"},
-			GetCertificate: certWatcher.GetCertificate,
-			MinVersion:     tls.VersionTLS10,
-		}
-		listener, err = tls.Listen("tcp", net.JoinHostPort("127.0.0.1", "8083"), cfg)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		listener, err = net.Listen("tcp", net.JoinHostPort("127.0.0.1", "8082"))
-		if err != nil {
-			panic(err)
-		}
+	srv := webhook.Server{
+		Host:       "127.0.0.1",
+		Port:       8083,
+		CertDir:    *certDir,
+		CertName:   "tls.crt",
+		KeyName:    "tls.key",
+		WebhookMux: http.NewServeMux(),
 	}
-
-	fmt.Println("Server started")
 
 	operation1Handler, err := catalogHTTP.NewHandlerBuilder().
 		WithCatalog(c).
@@ -87,21 +47,9 @@ func main() {
 		panic(err)
 	}
 
-	srv := &http.Server{
-		Handler: operation1Handler,
-	}
+	srv.WebhookMux.Handle("/", operation1Handler)
 
-	go func() {
-		<-ctx.Done()
-
-		// TODO: use a context with reasonable timeout
-		if err := srv.Shutdown(context.Background()); err != nil {
-			// Error from closing listeners, or context timeout
-			panic("error shutting down the HTTP server")
-		}
-	}()
-
-	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+	if err := srv.StartStandalone(ctx, nil); err != nil {
 		panic(err)
 	}
 }

--- a/poc/test/rte-implementation-v1alpha1-secure/main.go
+++ b/poc/test/rte-implementation-v1alpha1-secure/main.go
@@ -29,12 +29,13 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	srv := webhook.Server{
-		Host:       "127.0.0.1",
-		Port:       8083,
-		CertDir:    *certDir,
-		CertName:   "tls.crt",
-		KeyName:    "tls.key",
-		WebhookMux: http.NewServeMux(),
+		Host:          "127.0.0.1",
+		Port:          8083,
+		CertDir:       *certDir,
+		CertName:      "tls.crt",
+		KeyName:       "tls.key",
+		WebhookMux:    http.NewServeMux(),
+		TLSMinVersion: "1.2",
 	}
 
 	operation1Handler, err := catalogHTTP.NewHandlerBuilder().


### PR DESCRIPTION
* adds tls handling for the client
* adds tls to `poc/test/rte-implementation-v1alpha1` via flags
* adds reimplementation of `poc/test/rte-implementation-v1alpha1` to `poc/test/rte-implementation-v1alpha1-secure` which re-uses controller-runtimes server implementation