### PR TITLE
:seedling:  add defaulting and more validation to Extension webhook

### DIFF
--- a/exp/runtime/api/v1beta1/extension_types.go
+++ b/exp/runtime/api/v1beta1/extension_types.go
@@ -93,7 +93,7 @@ type ServiceReference struct {
 	Path *string `json:"path,omitempty"`
 
 	// Port is the port on the service that hosting extension.
-	// Default to 443 for backward compatibility.
+	// Default to 8443 for backward compatibility.
 	// `port` should be a valid port number (1-65535, inclusive).
 	// +optional
 	Port *int32 `json:"port,omitempty"`

--- a/exp/runtime/api/v1beta1/extension_webhook.go
+++ b/exp/runtime/api/v1beta1/extension_webhook.go
@@ -18,14 +18,18 @@ package v1beta1
 
 import (
 	"fmt"
+	"net/url"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 )
 
@@ -47,51 +51,138 @@ func (e *Extension) Default() {
 	if e.Spec.NamespaceSelector == nil {
 		e.Spec.NamespaceSelector = &metav1.LabelSelector{}
 	}
+
+	// If a Service is defined default an unset port.
+	if e.Spec.ClientConfig.Service != nil {
+		if e.Spec.ClientConfig.Service.Port == nil {
+			e.Spec.ClientConfig.Service.Port = pointer.Int32(8443)
+		}
+	}
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (e *Extension) ValidateCreate() error {
-	// NOTE: Extensions is behind the RuntimeSDK feature gate flag; the web hook
-	// must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(feature.RuntimeSDK) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the RuntimeSDK feature flag is enabled",
-		)
-	}
-
-	// NOTE: Extensions is also behind the ClusterTopology feature gate flag; the web hook
-	// must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(feature.ClusterTopology) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the ClusterTopology feature flag is enabled",
-		)
-	}
-	return nil
+	return e.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (e *Extension) ValidateUpdate(old runtime.Object) error {
-	if !feature.Gates.Enabled(feature.RuntimeSDK) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the RuntimeSDK feature flag is enabled",
-		)
-	}
-
-	// NOTE: Extensions is also behind the ClusterTopology feature gate flag; the web hook
-	// must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(feature.ClusterTopology) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the ClusterTopology feature flag is enabled",
-		)
-	}
-	if _, ok := old.(*Extension); !ok {
+	newExtension, ok := old.(*Extension)
+	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected an Extension but got a %T", old))
 	}
+	return e.validate(newExtension)
+}
+
+func (e *Extension) validate(old *Extension) error {
+	specPath := field.NewPath("spec")
+	var allErrs field.ErrorList
+	// NOTE: ExtensionConfig is behind the RuntimeSDK feature gate flag; the web hook
+	// must prevent creating and updating objects old case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.RuntimeSDK) {
+		allErrs = append(allErrs, field.Forbidden(
+			specPath,
+			"can be set only if the RuntimeSDK feature flag is enabled",
+		))
+	}
+
+	allErrs = append(allErrs, validateExtensionSpec(e)...)
+
+	// ValidateUpdate if old is not nil.
+	if old != nil {
+		allErrs = append(allErrs, validateExtensionSpec(old)...)
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("Extension").GroupKind(), e.Name, allErrs)
+	}
 	return nil
+}
+
+func validateExtensionSpec(e *Extension) field.ErrorList {
+	var allErrs field.ErrorList
+
+	specPath := field.NewPath("spec")
+
+	if e.Spec.ClientConfig.URL == nil && e.Spec.ClientConfig.Service == nil {
+		allErrs = append(allErrs, field.Required(
+			specPath.Child("clientConfig"),
+			"either URL or Service must be defined",
+		))
+	}
+
+	// Validate URl
+	if e.Spec.ClientConfig.URL != nil {
+		if _, err := url.ParseRequestURI(*e.Spec.ClientConfig.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				specPath.Child("clientConfig", "url"),
+				*e.Spec.ClientConfig.URL,
+				"must be a valid URL e.g. https://example.com",
+			))
+		}
+		// TODO: Decide handling of http/https prefixes.
+	}
+
+	// Validate Service if defined
+	if e.Spec.ClientConfig.Service != nil {
+		// Validate that the name is not empty and is a Valid RFC1123 name.
+		if e.Spec.ClientConfig.Service.Name == "" {
+			allErrs = append(allErrs, field.Required(
+				specPath.Child("clientConfig", "service", "name"),
+				"must not be empty",
+			))
+		}
+
+		if errs := validation.IsDNS1123Subdomain(e.Spec.ClientConfig.Service.Name); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(
+				specPath.Child("clientConfig", "service", "name"),
+				e.Spec.ClientConfig.Service.Name,
+				"invalid name",
+			))
+		}
+
+		// TODO: Decide if we need to validate Namespace (should it be equal to some other Namespace?)
+		if e.Spec.ClientConfig.Service.Namespace == "" {
+			allErrs = append(allErrs, field.Required(
+				specPath.Child("clientConfig", "service", "namespace"),
+				"must not be empty",
+			))
+		}
+
+		if e.Spec.ClientConfig.Service.Path != nil {
+			// TODO: Decide if we should be this strict on the path.
+			path := *e.Spec.ClientConfig.Service.Path
+			if _, err := url.ParseRequestURI(path); err != nil {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "path"),
+					path,
+					"must be a valid URL path e.g. /path/to/hook",
+				))
+			}
+			if path[0:1] != "/" {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "path"),
+					path,
+					"must be a valid URL path e.g. /path/to/hook",
+				))
+			}
+		}
+		if e.Spec.ClientConfig.Service.Port != nil {
+			if errs := validation.IsValidPortNum(int(*e.Spec.ClientConfig.Service.Port)); len(errs) != 0 {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "port"),
+					*e.Spec.ClientConfig.Service.Port,
+					"must be in range 1-65535 inclusive",
+				))
+			}
+		}
+	}
+	if e.Spec.NamespaceSelector == nil {
+		allErrs = append(allErrs, field.Required(
+			specPath.Child("NamespaceSelector"),
+			"must be defined",
+		))
+	}
+	return allErrs
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/exp/runtime/api/v1beta1/extension_webhook_test.go
+++ b/exp/runtime/api/v1beta1/extension_webhook_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/cluster-api/feature"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
+)
+
+var (
+	fakeScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = AddToScheme(fakeScheme)
+}
+
+func TestExtensionDefault(t *testing.T) {
+	g := NewWithT(t)
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)()
+
+	extension := &Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-extension",
+		},
+		Spec: ExtensionSpec{
+			ClientConfig: ExtensionClientConfig{
+				Service: &ServiceReference{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			},
+		},
+	}
+	t.Run("for Extension", utildefaulting.DefaultValidateTest(extension))
+	extension.Default()
+
+	g.Expect(extension.Spec.NamespaceSelector).To(Equal(&metav1.LabelSelector{}))
+	g.Expect(extension.Spec.ClientConfig.Service.Port).To(Equal(pointer.Int32(8443)))
+}
+
+func TestExtensionConfigValidate(t *testing.T) {
+	extensionWithURL := &Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-extension",
+		},
+		Spec: ExtensionSpec{
+			ClientConfig: ExtensionClientConfig{
+				URL: pointer.String("https://extension-address.com"),
+			},
+		},
+	}
+
+	extensionWithService := &Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-extension",
+		},
+		Spec: ExtensionSpec{
+			ClientConfig: ExtensionClientConfig{
+				Service: &ServiceReference{
+					Path:      pointer.StringPtr("/path/to/handler"),
+					Port:      pointer.Int32(1),
+					Name:      "foo",
+					Namespace: "bar",
+				}},
+		},
+	}
+
+	// Valid updated Extension
+	updatedExtension := extensionWithURL.DeepCopy()
+	updatedExtension.Spec.ClientConfig.URL = pointer.StringPtr("https://a-in-extension-address.com")
+
+	badURLExtension := extensionWithURL.DeepCopy()
+	badURLExtension.Spec.ClientConfig.URL = pointer.String("https//extension-address.com")
+
+	extensionWithoutURLOrService := extensionWithURL.DeepCopy()
+	extensionWithoutURLOrService.Spec.ClientConfig.URL = nil
+
+	extensionWithInvalidServicePath := extensionWithService.DeepCopy()
+	extensionWithInvalidServicePath.Spec.ClientConfig.Service.Path = pointer.StringPtr("https://example.com")
+
+	extensionWithInvalidServicePort := extensionWithService.DeepCopy()
+	extensionWithInvalidServicePort.Spec.ClientConfig.Service.Port = pointer.Int32(90000)
+
+	tests := []struct {
+		name        string
+		in          *Extension
+		old         *Extension
+		featureGate bool
+		expectErr   bool
+	}{
+		{
+			name:        "creation should fail if feature flag is disabled",
+			in:          extensionWithURL,
+			featureGate: false,
+			expectErr:   true,
+		},
+		{
+			name:        "update should fail if feature flag is disabled",
+			old:         extensionWithURL,
+			in:          updatedExtension,
+			featureGate: false,
+			expectErr:   true,
+		},
+		{
+			name:        "update should fail if URL is invalid",
+			old:         extensionWithURL,
+			in:          badURLExtension,
+			featureGate: true,
+			expectErr:   true,
+		},
+		{
+			name:        "update should fail if URL and Service are both nil",
+			old:         extensionWithURL,
+			in:          extensionWithoutURLOrService,
+			featureGate: true,
+			expectErr:   true,
+		},
+
+		{
+			name:        "update should fail if Service Path is invalid",
+			old:         extensionWithService,
+			in:          extensionWithInvalidServicePath,
+			featureGate: true,
+			expectErr:   true,
+		},
+
+		{
+			name:        "update should fail if Service Port is invalid",
+			old:         extensionWithService,
+			in:          extensionWithInvalidServicePort,
+			featureGate: true,
+			expectErr:   true,
+		},
+		{
+			name:        "update should pass if Service Path is valid",
+			old:         extensionWithService,
+			in:          extensionWithService,
+			featureGate: true,
+			expectErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, tt.featureGate)()
+			g := NewWithT(t)
+
+			// Default the objects so we're not handling defaulted cases.
+			tt.in.Default()
+			if tt.old != nil {
+				tt.old.Default()
+			}
+
+			err := tt.in.validate(tt.old)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}

--- a/exp/runtime/internal/controllers/extension_controller_test.go
+++ b/exp/runtime/internal/controllers/extension_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -41,8 +42,9 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: runtimev1.ExtensionSpec{
-			ClientConfig:      runtimev1.ExtensionClientConfig{},
-			NamespaceSelector: nil,
+			ClientConfig: runtimev1.ExtensionClientConfig{
+				URL: pointer.String("https://extension-address.com"),
+			},
 		},
 	}
 	workingExtension2 := workingExtension1.DeepCopy()
@@ -57,7 +59,9 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: runtimev1.ExtensionSpec{
-			ClientConfig:      runtimev1.ExtensionClientConfig{},
+			ClientConfig: runtimev1.ExtensionClientConfig{
+				URL: pointer.String("https://extension-address.com"),
+			},
 			NamespaceSelector: nil,
 		},
 	}
@@ -161,8 +165,8 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		g.Expect(env.CreateAndWait(ctx, brokenExtension.DeepCopy())).To(Succeed())
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName(brokenExtension)})
 		g.Expect(err).NotTo(BeNil())
-
-		g.Expect(env.GetAPIReader().List(ctx, &results)).To(Succeed())
+		time.Sleep(time.Millisecond * 500)
+		g.Expect(env.List(ctx, &results)).To(Succeed())
 		for _, extension := range results.Items {
 			if extension.Name == workingExtension1.Name {
 				g.Expect(len(extension.GetConditions())).To(Not(Equal(0)))


### PR DESCRIPTION
Adds webhook defaulting and a first round of validation for the Extension object.

This is quite a bit removed from the upstream version that adds the API types at this point - but is shouldn't be too difficult to refactor.