### PR TITLE
✨ defaulting and validation for ExtensionConfig

### DIFF
--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -31,6 +31,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
 )
 
 func TestClusterDefaultNamespaces(t *testing.T) {
@@ -46,7 +47,7 @@ func TestClusterDefaultNamespaces(t *testing.T) {
 		},
 	}
 	webhook := &Cluster{}
-	tFunc := customDefaultValidateTest(ctx, c, webhook)
+	tFunc := util.CustomDefaultValidateTest(ctx, c, webhook)
 
 	t.Run("for Cluster", tFunc)
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
@@ -317,7 +318,7 @@ func TestClusterDefaultVariables(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// Test if defaulting works in combination with validation.
-			customDefaultValidateTest(ctx, cluster, webhook)(t)
+			util.CustomDefaultValidateTest(ctx, cluster, webhook)(t)
 			// Test defaulting.
 			t.Run("default", func(t *testing.T) {
 				g := NewWithT(t)
@@ -350,7 +351,7 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &Cluster{Client: fakeClient}
-	tFunc := customDefaultValidateTest(ctx, c, webhook)
+	tFunc := util.CustomDefaultValidateTest(ctx, c, webhook)
 	t.Run("for Cluster", tFunc)
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -34,6 +34,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
 )
 
 var (
@@ -76,7 +77,7 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &ClusterClass{Client: fakeClient}
-	tFunc := customDefaultValidateTest(ctx, in, webhook)
+	tFunc := util.CustomDefaultValidateTest(ctx, in, webhook)
 
 	t.Run("for ClusterClass", tFunc)
 

--- a/internal/webhooks/runtime/extensionconfig_webhook.go
+++ b/internal/webhooks/runtime/extensionconfig_webhook.go
@@ -19,11 +19,14 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -58,6 +61,11 @@ func (webhook *ExtensionConfig) Default(ctx context.Context, obj runtime.Object)
 	if extensionConfig.Spec.NamespaceSelector == nil {
 		extensionConfig.Spec.NamespaceSelector = &metav1.LabelSelector{}
 	}
+	if extensionConfig.Spec.ClientConfig.Service != nil {
+		if extensionConfig.Spec.ClientConfig.Service.Port == nil {
+			extensionConfig.Spec.ClientConfig.Service.Port = pointer.Int32(8443)
+		}
+	}
 	return nil
 }
 
@@ -84,7 +92,7 @@ func (webhook *ExtensionConfig) ValidateUpdate(ctx context.Context, old, updated
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *ExtensionConfig) validate(_ context.Context, _, _ *runtimev1.ExtensionConfig) error {
+func (webhook *ExtensionConfig) validate(_ context.Context, _, newExtensionConfig *runtimev1.ExtensionConfig) error {
 	// NOTE: ExtensionConfig is behind the RuntimeSDK feature gate flag; the web hook
 	// must prevent creating and updating objects in case the feature flag is disabled.
 	if !feature.Gates.Enabled(feature.RuntimeSDK) {
@@ -93,10 +101,110 @@ func (webhook *ExtensionConfig) validate(_ context.Context, _, _ *runtimev1.Exte
 			"can be set only if the RuntimeSDK feature flag is enabled",
 		)
 	}
+
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, validateExtensionConfigSpec(newExtensionConfig)...)
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(runtimev1.GroupVersion.WithKind("ExtensionConfig").GroupKind(), newExtensionConfig.Name, allErrs)
+	}
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *ExtensionConfig) ValidateDelete(_ context.Context, _ runtime.Object) error {
 	return nil
+}
+
+func validateExtensionConfigSpec(e *runtimev1.ExtensionConfig) field.ErrorList {
+	var allErrs field.ErrorList
+
+	specPath := field.NewPath("spec")
+
+	if e.Spec.ClientConfig.URL == nil && e.Spec.ClientConfig.Service == nil {
+		allErrs = append(allErrs, field.Required(
+			specPath.Child("clientConfig"),
+			"either URL or Service must be defined",
+		))
+	}
+	if e.Spec.ClientConfig.URL != nil && e.Spec.ClientConfig.Service != nil {
+		allErrs = append(allErrs, field.Forbidden(
+			specPath.Child("clientConfig"),
+			"only one of URL or Service can be defined",
+		))
+	}
+
+	// Validate URl
+	if e.Spec.ClientConfig.URL != nil {
+		if _, err := url.ParseRequestURI(*e.Spec.ClientConfig.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				specPath.Child("clientConfig", "url"),
+				*e.Spec.ClientConfig.URL,
+				"must be a valid URL e.g. https://example.com",
+			))
+		}
+		// TODO: Decide handling of http/https prefixes.
+	}
+
+	// Validate Service if defined
+	if e.Spec.ClientConfig.Service != nil {
+		// Validate that the name is not empty and is a Valid RFC1123 name.
+		if e.Spec.ClientConfig.Service.Name == "" {
+			allErrs = append(allErrs, field.Required(
+				specPath.Child("clientConfig", "service", "name"),
+				"must not be empty",
+			))
+		}
+
+		if errs := validation.IsDNS1123Subdomain(e.Spec.ClientConfig.Service.Name); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(
+				specPath.Child("clientConfig", "service", "name"),
+				e.Spec.ClientConfig.Service.Name,
+				"invalid name",
+			))
+		}
+
+		// TODO: Decide if we need to validate Namespace (should it be equal to some other Namespace?)
+		if e.Spec.ClientConfig.Service.Namespace == "" {
+			allErrs = append(allErrs, field.Required(
+				specPath.Child("clientConfig", "service", "namespace"),
+				"must not be empty",
+			))
+		}
+
+		if e.Spec.ClientConfig.Service.Path != nil {
+			// TODO: Decide if we should be this strict on the path.
+			path := *e.Spec.ClientConfig.Service.Path
+			if _, err := url.ParseRequestURI(path); err != nil {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "path"),
+					path,
+					"must be a valid URL path e.g. /path/to/hook",
+				))
+			}
+			if path[0:1] != "/" {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "path"),
+					path,
+					"must be a valid URL path e.g. /path/to/hook",
+				))
+			}
+		}
+		if e.Spec.ClientConfig.Service.Port != nil {
+			if errs := validation.IsValidPortNum(int(*e.Spec.ClientConfig.Service.Port)); len(errs) != 0 {
+				allErrs = append(allErrs, field.Invalid(
+					specPath.Child("clientConfig", "service", "port"),
+					*e.Spec.ClientConfig.Service.Port,
+					"must be in range 1-65535 inclusive",
+				))
+			}
+		}
+	}
+	if e.Spec.NamespaceSelector == nil {
+		allErrs = append(allErrs, field.Required(
+			specPath.Child("NamespaceSelector"),
+			"must be defined",
+		))
+	}
+	return allErrs
 }

--- a/internal/webhooks/util/util.go
+++ b/internal/webhooks/util/util.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhooks
+// Package util includes the util functions webhooks.
+package util
 
 import (
 	"context"
@@ -25,17 +26,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// customDefaulterValidator interface is for objects that define both custom defaulting
+// CustomDefaulterValidator interface is for objects that define both custom defaulting
 // and custom validating webhooks.
-type customDefaulterValidator interface {
+type CustomDefaulterValidator interface {
 	webhook.CustomDefaulter
 	webhook.CustomValidator
 }
 
-// customDefaultValidateTest returns a new testing function to be used in tests to
+// CustomDefaultValidateTest returns a new testing function to be used in tests to
 // make sure custom defaulting webhooks also pass validation tests on create,
 // update and delete.
-func customDefaultValidateTest(ctx context.Context, obj runtime.Object, webhook customDefaulterValidator) func(*testing.T) {
+func CustomDefaultValidateTest(ctx context.Context, obj runtime.Object, webhook CustomDefaulterValidator) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Looks like the new defaulting and validation code somehow got missed. Might be during the rebase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
